### PR TITLE
fix getPrettyAxisBreaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspGraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.5.2.4
+Version: 0.5.2.5
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: Graph making functions and wrappers for JASP.

--- a/R/getPrettyAxisBreaks.R
+++ b/R/getPrettyAxisBreaks.R
@@ -1,8 +1,8 @@
-#' @title Compute axis breaks 
+#' @title Compute axis breaks
 #' @param x the object to compute axis breaks for
 #'
 #' @param ... if x is numeric, this is passed to pretty
-#' @details this is just a wrapper for pretty with slightly different defaults. 
+#' @details this is just a wrapper for pretty.
 #'
 #' @export
 getPrettyAxisBreaks <- function(x, ...) {
@@ -12,18 +12,7 @@ getPrettyAxisBreaks <- function(x, ...) {
 
 #' @export
 getPrettyAxisBreaks.numeric <- function(x, ...) {
-
-  dots <- list(...)
-
-  if (is.null(dots[["high.u.bias"]]))
-    xr <- range(x)
-  if (xr[2] - xr[1] > 1e3) { # big numbers, adjust pretty to favor less breaks
-    high.u.bias <- 2
-  } else { # default value
-    high.u.bias <-  1.5
-  }
-  dots[["x"]] <- x
-  return(do.call(base::pretty, dots))
+  return(base::pretty(x, ...))
 }
 
 #' @export

--- a/man/getPrettyAxisBreaks.Rd
+++ b/man/getPrettyAxisBreaks.Rd
@@ -15,5 +15,5 @@ getPrettyAxisBreaks(x, ...)
 Compute axis breaks
 }
 \details{
-this is just a wrapper for pretty with slightly different defaults.
+this is just a wrapper for pretty.
 }


### PR DESCRIPTION
Part of https://github.com/jasp-stats/jasp-test-release/issues/1315

So there was some code to change the defaults of `pretty` in some circumstances. However, the updated defaults were never actually passed to `pretty`... I think it's still useful to leave these wrappers as it allows us to adjust these settings in one place.

