### PR TITLE
Do not translate error messages intended for developers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspGraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.5.2.5
+Version: 0.5.2.6
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: Graph making functions and wrappers for JASP.

--- a/R/JASPgraphsPlot.R
+++ b/R/JASPgraphsPlot.R
@@ -6,12 +6,12 @@ jaspGraphsPlot <- R6::R6Class(
     initialize = function(subplots, plotFunction = reDrawJaspGraphsPlot, ...) {
 
       if (!all(vapply(subplots, is.ggplot, TRUE)))
-        stop("all subplots should be of class ggplot!")
+        stop2("all subplots should be of class ggplot!")
       if (!is.function(plotFunction))
-        stop("plotFunction should be a function!")
+        stop2("plotFunction should be a function!")
       plotArgs <- list(...)
       if (!length(names(plotArgs)) == length(plotArgs))
-        stop("all arguments in ... should be named.")
+        stop2("all arguments in ... should be named.")
       if (is.null(plotArgs[["names"]]) && identical(plotFunction, reDrawJaspGraphsPlot))
         plotArgs[["names"]] <- paste0("plot", seq_along(subplots))
 

--- a/R/PlotPieChart.R
+++ b/R/PlotPieChart.R
@@ -26,11 +26,11 @@ plotPieChart <- function(value, group,
                          ...) {
 
   if (!is.numeric(value))
-    stop("value should be numeric!")
+    stop2("value should be numeric!")
   if (!(is.character(group) || is.factor(group)))
-    stop("group should be a character or factor!")
+    stop2("group should be a character or factor!")
   if (length(value) != length(group))
-    stop("value and group should have the same length!")
+    stop2("value and group should have the same length!")
 
   # change the default arguments for themeJasp
   dots <- list(...)

--- a/R/PlotPizza.R
+++ b/R/PlotPizza.R
@@ -21,9 +21,9 @@ drawBFpizza <- function(dat, linewidth = 1, scaleText = 0.3, show.legend = FALSE
   # y = rotation from origin
   
   if (scaleText < 0)
-    stop("scaleText should be positive!")
+    stop2("scaleText should be positive!")
   if (linewidth < 0)
-    stop("linewidth should be positive!")
+    stop2("linewidth should be positive!")
 
   if (!is.data.frame(dat))
     dat <- data.frame(y = dat)

--- a/R/PlotPriorAndPosterior.R
+++ b/R/PlotPriorAndPosterior.R
@@ -42,7 +42,7 @@ getEmptyPlot <- function(axes = FALSE) {
 
 
   if (axes) {
-    stop("Not implemented")
+    stop2("Not implemented")
   } else {
     ggplot2::ggplot() + ggplot2::geom_blank() + getEmptyTheme()
   }
@@ -62,7 +62,7 @@ draw2Lines <- function(l, x = 0.5, parse = needsParsing(l), align = c("center", 
       "right"  = 1.0
     )
   } else {
-    stop("incorrect class for align. Expected character of numeric.")
+    stop2("incorrect class for align. Expected character of numeric.")
   }
 
   nLabels <- length(l)
@@ -95,16 +95,16 @@ errCheckPlots <- function(dfLines, dfPoints = NULL, CRI = NULL, median = NULL, B
 
   if (!all(is.data.frame(dfLines), !is.null(dfLines$x), !is.null(dfLines$y),
            ncol(dfLines) == 2L || !is.null(dfLines$g)))
-    stop("dfLines should be a data.frame with $x, $y, and $g!")
+    stop2("dfLines should be a data.frame with $x, $y, and $g!")
   if (!is.null(dfPoints) && !all(is.data.frame(dfPoints), !is.null(dfPoints$x), !is.null(dfPoints$y),
                                  ncol(dfPoints) == 2L || !is.null(dfPoints$g)))
-    stop("dfPoints should be a data.frame with $x, $y, and $g!")
+    stop2("dfPoints should be a data.frame with $x, $y, and $g!")
   if (errCheckPlotPriorAndPosterior(CRI, 2L))
-    stop("CRI should be numeric and have length 2! (left bound, right bound)")
+    stop2("CRI should be numeric and have length 2! (left bound, right bound)")
   if (errCheckPlotPriorAndPosterior(median))
-    stop("median should be numeric and have length 1!")
+    stop2("median should be numeric and have length 1!")
   if (errCheckPlotPriorAndPosterior(BF))
-    stop("BF should be numeric and have length 1!")
+    stop2("BF should be numeric and have length 1!")
 
   return(invisible(TRUE))
 }
@@ -209,7 +209,7 @@ makeBFlabels <- function(bfSubscripts, BFvalues, subs = NULL, bfTxt = NULL) {
     if (is.null(subs))
       subs <- unlist(stringr::str_extract_all(bfSubscripts, "(?<=\\[).+?(?=\\])")) # get everything between []
     if (length(subs) != length(BFvalues))
-      stop("bfSubscripts and BFvalues have different length!")
+      stop2("bfSubscripts and BFvalues have different length!")
     lab <- paste0("BF[", subs[2:1], "]", "[", subs[1:2], "] == ",
                   format(BFvalues, digits = getGraphOption("digits")[["BF"]])
     )

--- a/R/PlotRobustnessSequential.R
+++ b/R/PlotRobustnessSequential.R
@@ -69,7 +69,7 @@ PlotRobustnessSequential <- function(
   }
 
   if (!is.null(dfPoints) && !is.null(BF)) {
-    stop("Cannot provide both a BF pizzaplot and a points legend!")
+    stop2("Cannot provide both a BF pizzaplot and a points legend!")
   }
 
   yRange <- range(dfLines$y)
@@ -191,7 +191,7 @@ PlotRobustnessSequential <- function(
     scaleCol <- scaleLty <- scaleShape <- scaleFill <- scaleSize <- NULL
   } else {
     if (length(unique(dfLines$g)) != length(lineColors) || length(lineColors) != length(lineTypes))
-      stop("lineColors and lineTypes must have the same length as the number of groups in dfLines.")
+      stop2("lineColors and lineTypes must have the same length as the number of groups in dfLines.")
 
     if (plotLineOrPoint == "line") {
       mapping    <- aes(x = .data$x, y = .data$y, group = .data$g, linetype = .data$g, color = .data$g)

--- a/R/colorPalettes.R
+++ b/R/colorPalettes.R
@@ -27,9 +27,9 @@ jaspGraphs_data <- list2env(list(
 JASPcolors <- function(palette = getGraphOption("palette"), asFunction = FALSE) {
 
   if (!is.character(palette)) {
-    stop("palette must be character!")
+    stop2("palette must be character!")
   } else if (!palette %in% names(jaspGraphs_data)) {
-    stop(sprintf("palette was %s but must be one of %s", as.character(palette), paste(names(jaspGraphs_data), collapse = ", ")))
+    stop2(sprintf("palette was %s but must be one of %s", as.character(palette), paste(names(jaspGraphs_data), collapse = ", ")))
   }
   colors <- jaspGraphs_data[[palette]][["colors"]]
   if (asFunction) {

--- a/R/enums.R
+++ b/R/enums.R
@@ -3,9 +3,9 @@
 createEnum <- function(nameValuePairs) {
 
   if (!is.list(nameValuePairs))
-    stop("createEnum: nameValuePairs should be a list!")
+    stop2("createEnum: nameValuePairs should be a list!")
   if (length(unique(names(nameValuePairs))) != length(nameValuePairs))
-    stop("createEnum: unique names and values have different length!")
+    stop2("createEnum: unique names and values have different length!")
 
   e <- list2env(nameValuePairs)
   class(e) <- c("Enum", class(e))
@@ -14,7 +14,7 @@ createEnum <- function(nameValuePairs) {
 
 `$.Enum` <- function(x, y) {
   out <- NextMethod(x, y)
-  if (is.null(out)) stop(sprintf("nonexisting enum type %s!", y))
+  if (is.null(out)) stop2(sprintf("nonexisting enum type %s!", y))
   out
 }
 
@@ -23,9 +23,9 @@ is.Enum <- function(x) inherits(x, "Enum")
 switchEnum <- function(EXPR, ENUM, ..., warnIfNonExhaustive = TRUE, checkValidCases = TRUE) {
 
   if (!is.character(EXPR))
-    stop("EXPR should be character!")
+    stop2("EXPR should be character!")
   if (!is.Enum(ENUM))
-    stop("ENUM should an enum!")
+    stop2("ENUM should an enum!")
 
   call <- match.call()
   nmsInCall <- names(call)[-(1:3)]
@@ -34,7 +34,7 @@ switchEnum <- function(EXPR, ENUM, ..., warnIfNonExhaustive = TRUE, checkValidCa
     warning("switchEnum: no default case nor an exhaustive set of cases!")
 
   if (checkValidCases && length(invalid <- setdiff(nmsInCall[nmsInCall != ""], names(ENUM))) > 0L)
-    stop("switchEnum: Invalid case(s) detected: ", paste(invalid, collapse = ", "), "\n  Valid cases are: ", paste(names(ENUM), collapse = ", "))
+    stop2("switchEnum: Invalid case(s) detected: ", paste(invalid, collapse = ", "), "\n  Valid cases are: ", paste(names(ENUM), collapse = ", "))
 
   # this is a bit inefficient...
   idx <- names(ENUM)[match(EXPR, unlist(as.list(ENUM)), nomatch = 0L)]

--- a/R/functions.R
+++ b/R/functions.R
@@ -257,7 +257,7 @@ drawSmooth <- function(graph = NULL, dat = NULL, mapping = NULL, size = 2, metho
                        color = "gray", show.legend = FALSE, se = FALSE, alpha = 1, ...) {
 
     if (is.null(dat) && is.null(graph))
-        stop("Argument dat and graph cannot both be NULL.")
+        stop2("Argument dat and graph cannot both be NULL.")
 
     if (is.null(dat))
         dat <- ggplot2::ggplot_build(graph)$data[[1]][c("x", "y")]

--- a/R/geom_aligned_text.R
+++ b/R/geom_aligned_text.R
@@ -112,7 +112,7 @@ geom_aligned_text <- function(mapping = NULL, data = NULL, stat = "identity", po
                               na.rm = FALSE, show.legend = NA, inherit.aes = TRUE) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("You must specify either `position` or `nudge_x`/`nudge_y`.", 
+      stop2("You must specify either `position` or `nudge_x`/`nudge_y`.",
            call. = FALSE)
     }
     position <- ggplot2::position_nudge(nudge_x, nudge_y)

--- a/R/ggMatrixPlot.R
+++ b/R/ggMatrixPlot.R
@@ -17,7 +17,7 @@ replicateOrStop <- function(x, n) {
   if (length(x) == 1) {
     x <- rep(x, n)
   } else if (length(x) != n) {
-    stop(sprintf(
+    stop2(sprintf(
       fmt = "Argument %s should either have length 1 or length %d.",
       deparse(substitute(x)), n
     ))
@@ -97,18 +97,18 @@ modifyAxesLabels <- function(removeXYlabels, plotList) {
 
   # Error handling
   if (!is.character(removeXYlabels) || !(all(removeXYlabels %in% c('x', 'y', 'xy', 'none'))))
-    stop("removeXYlabels must be a character and contain either 'x', 'y', 'xy', or 'none'")
+    stop2("removeXYlabels must be a character and contain either 'x', 'y', 'xy', or 'none'")
 
   d1 <- dim(plotList)
   if (is.matrix(removeXYlabels)) {
     d0 <- dim(removeXYlabels)
     if (!all(d0 == d1)) {
-      stop(sprintf("Dim(removeXYlabels) does not match dim(plotList) / layout. Got (%d, %d) and expected: (%d, %d).",
+      stop2(sprintf("Dim(removeXYlabels) does not match dim(plotList) / layout. Got (%d, %d) and expected: (%d, %d).",
                    d0[1], d0[2], d1[1], d1[2]))
     }
   } else {
     if (!(length(removeXYlabels) == 1 || length(plotList)))
-      stop("removeXYlabels should either have length 1 or length(plotList).")
+      stop2("removeXYlabels should either have length 1 or length(plotList).")
 
     removeXYlabels <- matrix(removeXYlabels, nrow = d1[1], ncol = d1[2])
   }
@@ -173,18 +173,18 @@ scaleAxesLabels <- function(scaleXYlabels, plotList) {
 
   # Error handling
   if (!is.numeric(scaleXYlabels) || !(all(scaleXYlabels > 0)) || !(all(scaleXYlabels < 1)))
-    stop("removeXYlabels must be numeric, larger than 0 and smaller than 1")
+    stop2("removeXYlabels must be numeric, larger than 0 and smaller than 1")
 
   d1 <- dim(plotList)
   if (is.matrix(scaleXYlabels)) {
     d0 <- dim(scaleXYlabels)
     if (!all(d0[1] == prod(d1))) {
-      stop(sprintf("dim(removeXYlabels)[1] does not match prod(dim(plotList)) / layout. Got (%d, %d) and expected: prod(%d, %d).",
+      stop2(sprintf("dim(removeXYlabels)[1] does not match prod(dim(plotList)) / layout. Got (%d, %d) and expected: prod(%d, %d).",
                    d0[1], d0[2], d1[1], d1[2]))
     }
   } else {
     if (!(length(scaleXYlabels) == 2 || length(plotList)))
-      stop("removeXYlabels should either have length 2 or length(plotList).")
+      stop2("removeXYlabels should either have length 2 or length(plotList).")
 
     scaleXYlabels <- matrix(scaleXYlabels, nrow = prod(d1), ncol = 2, byrow = TRUE)
   }
@@ -326,14 +326,14 @@ ggMatrixPlot.list <- function(plotList = NULL, nr = NULL, nc = NULL,
                               scaleXYlabels  = c(.9,.9),
                               debug          = FALSE) {
   if (is.null(layout)) { # was layout supplied?
-    stop("Either supply plotList as a matrix or provide a layout argument")
+    stop2("Either supply plotList as a matrix or provide a layout argument")
   } else if (!is.matrix(layout)) { # is layout layout a matrix?
-    stop(sprintf("layout must be a matrix but instead was of mode %s and class %s", mode(layout), class(layout)))
+    stop2(sprintf("layout must be a matrix but instead was of mode %s and class %s", mode(layout), class(layout)))
   } else if (length(layout) != length(plotList)) { # does layout have correct length?
-    stop(sprintf("length of layout (%d) does not match length of plotList (%d). Use NULL entries in plotList to specify empty plots.",
+    stop2(sprintf("length of layout (%d) does not match length of plotList (%d). Use NULL entries in plotList to specify empty plots.",
                  length(layout), length(plotList)))
   } else if (!all(seq_along(layout) %in% layout)) { # does layout have all required values?
-    stop("Layout must consist of unique integers starting from 1.")
+    stop2("Layout must consist of unique integers starting from 1.")
   } else {# layout is good layout
     plotList <- plotList[layout]
     nr <- nrow(layout)

--- a/R/jaspLabelAxes.R
+++ b/R/jaspLabelAxes.R
@@ -74,7 +74,7 @@ zero_range <- function(x, tol = 1000 * .Machine$double.eps) {
   if (length(x) == 1)
     return(TRUE)
   if (length(x) != 2)
-    stop("x must be length 1 or 2")
+    stop2("x must be length 1 or 2")
   if (any(is.na(x)))
     return(NA)
   if (x[1] == x[2])

--- a/R/jaspScales.R
+++ b/R/jaspScales.R
@@ -49,7 +49,7 @@ scale_x_continuous <- function(name = waiver(), breaks = getPrettyAxisBreaks, mi
       if (is.formula(sec.axis))
         sec.axis <- sec_axis(sec.axis)
       if (!is.sec_axis(sec.axis))
-        stop("Secondary axes must be specified using 'sec_axis()'")
+        stop2("Secondary axes must be specified using 'sec_axis()'")
       sc$secondary.axis <- sec.axis
     }
   }
@@ -67,7 +67,7 @@ set_sec_axis <- function(sec.axis, scale) {
     if (is.formula(sec.axis))
       sec.axis <- sec_axis(sec.axis)
     if (!is.sec_axis(sec.axis))
-      stop("Secondary axes must be specified using 'sec_axis()'", domain = NA)
+      stop2("Secondary axes must be specified using 'sec_axis()'")
     scale$secondary.axis <- sec.axis
   }
   return(scale)
@@ -104,7 +104,7 @@ scale_y_continuous <- function(name = waiver(), breaks = getPrettyAxisBreaks, mi
       if (is.formula(sec.axis))
         sec.axis <- sec_axis(sec.axis)
       if (!is.sec_axis(sec.axis))
-        stop("Secondary axes must be specified using 'sec_axis()'")
+        stop2("Secondary axes must be specified using 'sec_axis()'")
       sc$secondary.axis <- sec.axis
     }
   }

--- a/R/plotEditing.R
+++ b/R/plotEditing.R
@@ -35,12 +35,12 @@ toJSON    <- function(x) jsonlite::toJSON(x, auto_unbox = TRUE, digits = NA, nul
 validateOptions <- function(newOptions, oldOptions) {
 
   if (!is.list(newOptions)) {
-    stop("options should be an R list or a json string!")
+    stop2("options should be an R list or a json string!")
   }
 
   if (newOptions[["xAxis"]][["type"]] != oldOptions[["xAxis"]][["type"]] ||
       newOptions[["yAxis"]][["type"]] != oldOptions[["yAxis"]][["type"]]) {
-    stop("The axis type in the new options list does not match the graph!")
+    stop2("The axis type in the new options list does not match the graph!")
   }
 
 }
@@ -77,7 +77,7 @@ optionsDiff <- function(new, old) {
 plotEditing <- function(graph, newOptions) {
 
   if (!is.ggplot(graph))
-    stop("graph should be a ggplot2")
+    stop2("graph should be a ggplot2")
 
   if (isTRUE(newOptions[["resetPlot"]])) {
     if (hasOriginalEditingOptions(graph)) {

--- a/R/plotEditingOptions.R
+++ b/R/plotEditingOptions.R
@@ -121,5 +121,5 @@ is.coordPolar <- function(x) inherits(x, "CoordPolar")
 unsupportedFigureError <- function(message) {
   e <- structure(class = c("unsupportedFigureError", "error", "condition"),
                  list(message=message, call=sys.call(-1)))
-  stop(e)
+  stop2(e)
 }

--- a/R/printJASPgraphs.R
+++ b/R/printJASPgraphs.R
@@ -10,7 +10,7 @@ print.jaspGraphs <- function(x, ...) {
   } else if (length(class(x)) > 1L) {
     NextMethod()
   } else {
-    stop(sprintf(
+    stop2(sprintf(
       "unsupported plot object of class: %s",
       paste0(class(x), sep = ", ")
     ))

--- a/R/stop2.R
+++ b/R/stop2.R
@@ -1,0 +1,4 @@
+# identical to stop(), but these strings should not be translated
+stop2 <- function(..., call. = TRUE, domain = NA) {
+  stop(..., call. = call., domain = domain)
+}

--- a/R/themeApa.R
+++ b/R/themeApa.R
@@ -105,7 +105,7 @@ themeApaRaw <- function(legend.pos       = getGraphOption("legend.position"),
       "bottomright"  = theme(legend.position = c(0.95, 0.05), legend.justification = c(0.95, 0.05)),
       "bottommiddle" = theme(legend.position = c(0.5, 0.05),  legend.justification = c(0.5, 0.05)),
       "none" = theme(legend.position = "none"),
-      stop("unknown legend position string")
+      stop2("unknown legend position string")
     )
 
   theme <- theme + theme(


### PR DESCRIPTION
This PR introduces `stop2` instead of `stop`. `stop2` is identical to `stop`, except that it sets `domain = NA` instead of `domain = NULL`. That way, error messages returned by jaspGraphs won't be translated. For example, messages like these:
https://github.com/jasp-stats/jaspGraphs/blob/6575cbaf911ade98a1d9f638a5d1a6f81a6fe06c/po/R-jaspGraphs.pot#L13-L20

really do not need to be translated. If these errors occur, they're supposed to tell developers that they messed up and what they did wrong. A user should never see them as these are just R errors. If a user would somehow see them I would also prefer that their error report on GitHub shows a message in English, and not that I have to look up, say a Japanese translation of `"plotFunction should be a function!"`, before I can actually figure out what went wrong.


As an aside, there are strings in jaspGraphs that do need to be translated. Those are wrapped in `gettext` and `gettextf`.