### PR TITLE
Fix test issues with plot editing

### DIFF
--- a/R/plotEditingAxes.R
+++ b/R/plotEditingAxes.R
@@ -97,7 +97,7 @@ getAxisInfo <- function(x, opts, ggbuild) {
 
 getAxisInfo.ScaleContinuousPosition <- function(x, opts, ggbuild) {
 
-  xory <- x[["aesthetics"]][1L]
+  xory <- getXorY(x, ggbuild)
 
   opts2keep <- list(
     labels = opts[[1]][[xory]][["get_labels"]](),
@@ -109,6 +109,8 @@ getAxisInfo.ScaleContinuousPosition <- function(x, opts, ggbuild) {
 
   opts2keep[c("title", "titleType")] <- getAxisTitle(ggbuild, xory)
 
+  if (is.character(opts2keep[["breaks"]]) && !is.null(attr(opts2keep[["breaks"]], "pos")))
+    opts2keep[["breaks"]] <- attr(opts2keep[["breaks"]], "pos")
 
   if (is.null(opts2keep[["breaks"]])) {
 
@@ -160,7 +162,8 @@ getAxisInfo.ScaleContinuousPosition <- function(x, opts, ggbuild) {
 
 getAxisInfo.ScaleDiscretePosition <- function(x, opts, ggbuild) {
 
-  xory <- x[["aesthetics"]][1L]
+  xory <- getXorY(x, ggbuild)
+
   opts2keep <- list(
     labels = x[["get_labels"]](),
     # shown  = x[["get_limits"]](),
@@ -172,6 +175,16 @@ getAxisInfo.ScaleDiscretePosition <- function(x, opts, ggbuild) {
   if (is.null(opts2keep[["breaksType"]]))
 
   return(opts2keep)
+
+}
+
+getXorY <- function(x, ggbuild) {
+
+  xory <- x[["aesthetics"]][1L]
+  if (isCoordFlipped(ggbuild[["layout"]][["coord"]]))
+    if (xory == "x") return("y") else return("x")
+
+  return(xory)
 
 }
 

--- a/R/plotEditingAxes.R
+++ b/R/plotEditingAxes.R
@@ -163,7 +163,7 @@ getAxisInfo.ScaleDiscretePosition <- function(x, opts, ggbuild) {
   xory <- x[["aesthetics"]][1L]
   opts2keep <- list(
     labels = x[["get_labels"]](),
-    shown  = x[["get_limits"]](),
+    # shown  = x[["get_limits"]](),
     title  = getAxisTitle(ggbuild, xory)
   )
 

--- a/R/plotEditingOptions.R
+++ b/R/plotEditingOptions.R
@@ -53,7 +53,6 @@ getPlotEditingOptions.ggplot_built <- function(graph) {
   ySettings <- getAxisInfo(currentAxis[["y"]], opts, graph)
 
   if (isCoordFlipped(graph[["layout"]][["coord"]])) {
-    # names(axisTypes) <- rev(names(axisTypes))
     tmp <- xSettings
     xSettings <- ySettings
     ySettings <- tmp

--- a/R/plotEditingOptions.R
+++ b/R/plotEditingOptions.R
@@ -52,6 +52,13 @@ getPlotEditingOptions.ggplot_built <- function(graph) {
   xSettings <- getAxisInfo(currentAxis[["x"]], opts, graph)
   ySettings <- getAxisInfo(currentAxis[["y"]], opts, graph)
 
+  if (isCoordFlipped(graph[["layout"]][["coord"]])) {
+    # names(axisTypes) <- rev(names(axisTypes))
+    tmp <- xSettings
+    xSettings <- ySettings
+    ySettings <- tmp
+  }
+
   out <- list(
     xAxis = list(
       type     = axisTypes[["x"]],


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1463
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1476
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1481

This line
```r
# shown = x[["get_limits"]](),
```
was there so people can toggle what to show on discrete axes. However, there is no corresponding GUI element for it, so I commented it out. This caused https://github.com/jasp-stats/jasp-test-release/issues/1476 because the value for "shown" was `contNormal` but the plot expected `JaspColumn_.1._Encoded`. So in addition to a GUI element, it also may need some column encoding before it can be used in practice.

The multinomial plot stuff is due to additional issues with flipped coordinates, which I (mistakenly) though I had fixed.


To test this, it's easiest to install the package manually to "JASP-BUILD/R/library". That way jaspGraphs is in the first libPath and will always be loaded first.
