### PR TITLE
fixTranslationForExpression should just put backticks around every word

### DIFF
--- a/R/PlotRobustnessSequential.R
+++ b/R/PlotRobustnessSequential.R
@@ -425,28 +425,26 @@ PlotRobustnessSequential <- function(
 }
 
 
-.fixOnlyUnicodeWithBackticks <- function(textIn)
-{
+.fixOnlyUnicodeWithBackticks <- function(textIn) {
   textss <- strsplit(textIn, "\\s+")
   fixeds <- character()
 
-  for(texts in textss)
-  {
+  for (texts in textss) {
     fixed <- ""
-    for(text in texts)
-    {
+    for (text in texts) {
       putBackTicks <- Encoding(text) == "UTF-8"
 
-      if(!putBackTicks)
-        for(character in charToRaw(text))
-          if(character>127)
+      # the if can probably just be `putBackTicks <- any(charToRaw(text) > 127)`, let's fix that for next release
+      if (!putBackTicks)
+        for (character in charToRaw(text))
+          if (character > 127)
             putBackTicks <- TRUE
 
-      if(putBackTicks) #If unicode or outside of range of ascii then put backticks
+      if (putBackTicks) #If unicode or outside of range of ascii then put backticks
         text <- paste0('`',text,'`')
 
-      if(fixed == "") fixed <- text
-      else            fixed <- paste0(fixed, "~", text)
+      if (fixed == "") fixed <- text
+      else             fixed <- paste0(fixed, "~", text)
     }
     fixeds <- rbind(fixeds, fixed)
   }


### PR DESCRIPTION
That should help for things like "for" but also problems with "für"
- Fixes https://github.com/jasp-stats/jasp-test-release/issues/1523 (umlaut breaks plot)

`domain` shouldn't be necessary anymore as https://bugs.r-project.org/show_bug.cgi?id=18092 was for that. 