### PR TITLE
Add action for running downstream unit tests on comment

### DIFF
--- a/.github/workflows/downstream-tests-on-comment.yml
+++ b/.github/workflows/downstream-tests-on-comment.yml
@@ -1,0 +1,183 @@
+name: downstream-tests-on-comment
+
+on:
+  issue_comment:
+    types:
+    - created
+
+jobs:
+  get-pr-sha:
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/test-downstream'}}
+    runs-on: ubuntu-latest
+    
+    outputs:
+      sha: ${{ steps.sha.outputs.result }}
+    
+    steps:
+    - name: Get PR SHA
+      id: sha
+      uses: actions/github-script@v4
+      with:
+        result-encoding: string
+        script: |
+          const { owner, repo, number } = context.issue;
+          const pr = await github.pulls.get({
+            owner,
+            repo,
+            pull_number: number,
+          });
+          return pr.data.head.sha
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: get-pr-sha
+    continue-on-error: true
+    
+    name: ${{ matrix.os }} (${{ matrix.r }} (${{ matrix.module }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        r: [4.1.0]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        # only common modules
+        module: [jasp-stats/jaspDescriptives, jasp-stats/jaspTTests, jasp-stats/jaspAnova, jasp-stats/jaspRegression, jasp-stats/jaspFrequencies, jasp-stats/jaspFactor]
+        # for debugging
+#         os: [ubuntu-latest]
+#         module: [jasp-stats/jaspDescriptives, jasp-stats/jaspTTests]
+
+#    # outputs is generated with the following R code. It does not matter if some outputs are unused.
+#     oses      <- c("ubuntu-latest", "macOS-latest", "windows-latest")
+#     modules   <- c("jasp-stats/jaspDescriptives", "jasp-stats/jaspTTests", "jasp-stats/jaspAnova", "jasp-stats/jaspRegression", "jasp-stats/jaspFrequencies", "jasp-stats/jaspFactor")
+
+#     base <- "      %1$s-%2$s: ${{ steps.update-output.outputs.%1$s-%2$s }}"
+#     for (os in oses) for (module in modules)
+#       cat(sprintf(base, os, basename(module)), "\n")
+    outputs:
+      ubuntu-latest-jaspDescriptives: ${{ steps.update-output.outputs.ubuntu-latest-jaspDescriptives }} 
+      ubuntu-latest-jaspTTests: ${{ steps.update-output.outputs.ubuntu-latest-jaspTTests }} 
+      ubuntu-latest-jaspAnova: ${{ steps.update-output.outputs.ubuntu-latest-jaspAnova }} 
+      ubuntu-latest-jaspRegression: ${{ steps.update-output.outputs.ubuntu-latest-jaspRegression }} 
+      ubuntu-latest-jaspFrequencies: ${{ steps.update-output.outputs.ubuntu-latest-jaspFrequencies }} 
+      ubuntu-latest-jaspFactor: ${{ steps.update-output.outputs.ubuntu-latest-jaspFactor }} 
+      macOS-latest-jaspDescriptives: ${{ steps.update-output.outputs.macOS-latest-jaspDescriptives }} 
+      macOS-latest-jaspTTests: ${{ steps.update-output.outputs.macOS-latest-jaspTTests }} 
+      macOS-latest-jaspAnova: ${{ steps.update-output.outputs.macOS-latest-jaspAnova }} 
+      macOS-latest-jaspRegression: ${{ steps.update-output.outputs.macOS-latest-jaspRegression }} 
+      macOS-latest-jaspFrequencies: ${{ steps.update-output.outputs.macOS-latest-jaspFrequencies }} 
+      macOS-latest-jaspFactor: ${{ steps.update-output.outputs.macOS-latest-jaspFactor }} 
+      windows-latest-jaspDescriptives: ${{ steps.update-output.outputs.windows-latest-jaspDescriptives }} 
+      windows-latest-jaspTTests: ${{ steps.update-output.outputs.windows-latest-jaspTTests }} 
+      windows-latest-jaspAnova: ${{ steps.update-output.outputs.windows-latest-jaspAnova }} 
+      windows-latest-jaspRegression: ${{ steps.update-output.outputs.windows-latest-jaspRegression }} 
+      windows-latest-jaspFrequencies: ${{ steps.update-output.outputs.windows-latest-jaspFrequencies }} 
+      windows-latest-jaspFactor: ${{ steps.update-output.outputs.windows-latest-jaspFactor }} 
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.get-pr-sha.outputs.sha }}
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+         r-version: ${{ matrix.r }}
+
+      - name: clone module
+        run: |
+          echo cloning "https://github.com/${{ matrix.module }}.git"
+          git clone "https://github.com/${{ matrix.module }}.git"
+        shell: bash
+        
+      - uses: jasp-stats/jasp-actions/setup-test-env@master
+
+      - name: Install igraph from source
+        if: ${{ matrix.os }} == 'ubuntu-latest' && ${{ matrix.module }} == 'jasp-stats/jaspFactor'
+        run: install.packages("igraph", type = "source", repos = "https://cloud.r-project.org")
+        shell: Rscript {0}
+
+      - name: Install jaspGraphs
+        run: |
+           print(sprintf("Installing jaspGraphs from commit %s and ref %s", Sys.getenv("GITHUB_SHA", unset = "MISSING SHA!"), Sys.getenv("GITHUB_REF", unset = "MISSING REF!")))
+           remotes::install_local(".")
+        shell: Rscript {0}
+
+      - name: Run unit tests
+        run: |
+          setwd(basename("${{ matrix.module }}"))
+          source("tests/testthat.R")
+        shell: Rscript {0}
+        
+#       - name: fake unit tests for debugging
+#         run: |
+#           if [ ${{ matrix.module }} == 'jasp-stats/jaspDescriptives' ]; then
+#             exit 1
+#           fi
+#         shell: bash
+       
+      - name: set error if tests fail
+        id: update-output
+        if: ${{ failure() }}
+        run: |
+          moduleName=$(basename ${{ matrix.module }})
+          nm="${{ matrix.os }}-${moduleName}"
+          echo "nm = $nm"
+          echo "::set-output name=${nm}::error"
+        shell: bash
+
+  report-results:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    
+    steps:
+
+      - name: Aggregate results & post comment output
+        id: aggregated-results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+
+            const { NEEDS } = process.env
+            console.log(`${NEEDS}`)
+
+            results=JSON.parse(NEEDS);
+            console.log(results)
+            
+            outputs=results["unit-tests"]["outputs"];
+            for (const prop in outputs) { console.log(`${prop}: ${outputs[prop]}`);}
+            
+            if (Object.keys(outputs).length === 0) {
+              console.log("All unit tests succeeded")
+              body = "All downstream unit tests succeeded! ✅"
+            } else {
+              console.log("Some unit tests failed")
+            
+              obj = {}; // dict from module to os
+              for (const key in outputs) {
+                var [os, module] = key.split(/\-(?=[^\-]+$)/);
+                console.log(os, "|", module)
+                if (!(module in obj))
+                  obj[module] = new Set();
+                obj[module].add(os);
+              }
+              
+              body = "The following downstream unit tests failed:\n| Module | windows-latest | maxOS-latest | ubuntu-latest |\n| ---: | :---: | :---: | :---: |"
+              oses = ["windows-latest", "macOS-latest", "ubuntu-latest"];
+              for (const module in obj) {
+                str = "\n| ".concat(module, " | ", oses.map(os => obj[module].has(os) ? "❌" : "✅").join(" | "));
+                body=body.concat(str);
+                console.log(body)
+              }
+            }
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });

--- a/.github/workflows/downstream-tests-on-comment.yml
+++ b/.github/workflows/downstream-tests-on-comment.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
     - name: Get PR SHA
       id: sha
-      uses: actions/github-script@v4
+      uses: actions/github-script@v5
       with:
         result-encoding: string
         script: |
           const { owner, repo, number } = context.issue;
-          const pr = await github.pulls.get({
+          const pr = await github.rest.pulls.get({
             owner,
             repo,
             pull_number: number,
@@ -29,7 +29,7 @@ jobs:
           return pr.data.head.sha
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: get-pr-sha
     continue-on-error: true
     

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+    paths: ['**.R', '**.Rd']
 
 name: pkgdown
 

--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on: 
+  push:
+    paths: ['**.R', '**.svg', '**.Rd', 'DESCRIPTION', 'NAMESPACE']
+  pull_request:
+    paths: ['**.R', '**.svg', '**.Rd', 'DESCRIPTION', 'NAMESPACE']
 
 name: R-CMD-check
 
@@ -14,7 +18,7 @@ jobs:
         config:
           - {os: windows-latest, r: '4.1.0'}
           - {os: macOS-latest,   r: '4.1.0'}
-          - {os: ubuntu-20.04,   r: '4.1.0', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-latest,  r: '4.1.0', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true


### PR DESCRIPTION
Post `/test-downstream` as a comment in a PR and the unit tests for all common modules are run. The results are posted as a comment.

If any tests fail, you get [this reply](https://github.com/vandenman/jaspGraphs/pull/2#issuecomment-988650250):

> The following downstream unit tests failed:
> | Module | windows-latest | maxOS-latest | ubuntu-latest |
> | ---: | :---: | :---: | :---: |
> | jaspAnova | ❌ | ❌ | ❌
> | jaspDescriptives | ❌ | ❌ | ❌
> | jaspFrequencies | ❌ | ❌ | ❌
> | jaspRegression | ❌ | ❌ | ❌
> | jaspTTests | ❌ | ❌ | ❌

modules without any test failures (in this case jaspFactor) are omitted from the table.

If all tests pass, you get [this reply](https://github.com/vandenman/jaspGraphs/pull/2#issuecomment-988633923):

> All downstream unit tests succeeded! ✅

@TimKDJ, @JorisGoosen:

- Any comments on the action?
  - Note that I did not find a way to do this without hardcoding the `outputs` of the job `unit-tests`, so I generated the code.
- Any complaints if I add similar actions to jaspBase and jaspResults?

