### PR TITLE
Fixes crashes when BF = Inf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspGraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.5.2.11
+Version: 0.5.2.12
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: Graph making functions and wrappers for JASP.

--- a/R/PlotPizza.R
+++ b/R/PlotPizza.R
@@ -19,7 +19,7 @@ drawBFpizza <- function(dat, linewidth = 1, scaleText = 0.3, show.legend = FALSE
   # NOTE: this function uses polar coordinates! this implies:
   # x = distance from center
   # y = rotation from origin
-  
+
   if (scaleText < 0)
     stop2("scaleText should be positive!")
   if (linewidth < 0)
@@ -31,7 +31,7 @@ drawBFpizza <- function(dat, linewidth = 1, scaleText = 0.3, show.legend = FALSE
   errCheckPlotPriorAndPosterior(dat[["y"]], 2L)
 
 
-	dat$group <- factor(seq(dat[[1]]))
+  dat[["group"]] <- factor(seq(dat[["y"]]))
 
   yInfinite <- is.infinite(dat[["y"]])
   if (all(yInfinite)) {
@@ -42,38 +42,38 @@ drawBFpizza <- function(dat, linewidth = 1, scaleText = 0.3, show.legend = FALSE
     dat[["y"]] <- dat[["y"]] / sum(dat[["y"]])
   }
 
-	nms <- colnames(dat)
-	mapping <- ggplot2::aes_string(x = factor(1), y = nms[1], group = nms[2], fill = nms[2], color = nms[2])
+  nms <- colnames(dat)
+  mapping <- ggplot2::aes_string(x = factor(1), y = nms[1], group = nms[2], fill = nms[2], color = nms[2])
 
-	# rotate the wheel so that smaller half is always facing up
-	ma <- max(dat[[1]])
-	mi <- min(dat[[1]])
+  # rotate the wheel so that smaller half is always facing up
+  ma <- max(dat[["y"]])
+  mi <- min(dat[["y"]])
 
-	if (dat$y[1L] <= dat$y[2L]) {
-	  area <- mi / (mi + ma)
-	} else {
-	  area <- ma / (mi + ma)
-	}
-	start <- 0 + area * pi
+  if (dat[["y"]][1L] <= dat[["y"]][2L]) {
+    area <- mi / (mi + ma)
+  } else {
+    area <- ma / (mi + ma)
+  }
+  start <- 0 + area * pi
 
-	g <- ggplot(data = dat, mapping = mapping) +
-	  ggplot2::geom_bar(width = 1, stat = "identity", show.legend = show.legend, size = linewidth) +
-	  ggplot2::scale_x_discrete(expand = c(0, 0)) + scale_y_continuous(expand = c(0, 0)) +
-	  ggplot2::coord_polar(theta = "y", start = start) +
-	  ggplot2::scale_fill_manual(values  = c("darkred", "white")) +
-	  ggplot2::scale_color_manual(values = c("black", "black")) +
-	  getEmptyTheme()
+  g <- ggplot(data = dat, mapping = mapping) +
+    ggplot2::geom_bar(width = 1, stat = "identity", show.legend = show.legend, size = linewidth) +
+    ggplot2::scale_x_discrete(expand = c(0, 0)) + scale_y_continuous(expand = c(0, 0)) +
+    ggplot2::coord_polar(theta = "y", start = start) +
+    ggplot2::scale_fill_manual(values  = c("darkred", "white")) +
+    ggplot2::scale_color_manual(values = c("black", "black")) +
+    getEmptyTheme()
 
-	if (!is.null(labels)) {
-	  dfTxt <- data.frame(
-	    x = 2.1,                                           # distance from wheel
-	    y = c(dat$y[2L] / 2.0, dat$y[2L] + dat$y[1L] / 2), # rotation around wheel
-	    l = labels
-	  )
-	  g <- g + ggplot2::geom_text(data = dfTxt, aes(x = .data$x, y = .data$y, label = .data$l),
+  if (!is.null(labels)) {
+    dfTxt <- data.frame(
+      x = 2.1,                                                          # distance from wheel
+      y = c(dat[["y"]][2L] / 2.0, dat[["y"]][2L] + dat[["y"]][1L] / 2), # rotation around wheel
+      l = labels
+    )
+    g <- g + ggplot2::geom_text(data = dfTxt, aes(x = .data$x, y = .data$y, label = .data$l),
                                 parse = needsParsing(labels),
-	                              size = scaleText * getGraphOption("fontsize"), inherit.aes = FALSE)
-	}
+                                size = scaleText * getGraphOption("fontsize"), inherit.aes = FALSE)
+  }
 
-	return(g)
+  return(g)
 }

--- a/R/PlotPizza.R
+++ b/R/PlotPizza.R
@@ -33,8 +33,13 @@ drawBFpizza <- function(dat, linewidth = 1, scaleText = 0.3, show.legend = FALSE
 
 	dat$group <- factor(seq(dat[[1]]))
 
+  if(sum(is.infinite(dat$y)) > 1)
+    stop("More than one group with infinite evidence")
+	else if(sum(is.infinite(dat$y)) == 1)
+	  dat$y <- ifelse(is.infinite(dat$y), 1, 0)
+	else
+	  dat$y <- dat$y / sum(dat$y)
 
-	dat$y <- dat$y / sum(dat$y)
 	nms <- colnames(dat)
 	mapping <- ggplot2::aes_string(x = factor(1), y = nms[1], group = nms[2], fill = nms[2], color = nms[2])
 

--- a/R/PlotPizza.R
+++ b/R/PlotPizza.R
@@ -33,12 +33,14 @@ drawBFpizza <- function(dat, linewidth = 1, scaleText = 0.3, show.legend = FALSE
 
 	dat$group <- factor(seq(dat[[1]]))
 
-  if(sum(is.infinite(dat$y)) > 1)
-    stop("More than one group with infinite evidence")
-	else if(sum(is.infinite(dat$y)) == 1)
-	  dat$y <- ifelse(is.infinite(dat$y), 1, 0)
-	else
-	  dat$y <- dat$y / sum(dat$y)
+  yInfinite <- is.infinite(dat[["y"]])
+  if (all(yInfinite)) {
+    stop2("More than one group with infinite evidence")
+  } else if (any(yInfinite)) {
+    dat[["y"]] <- ifelse(yInfinite, 1, 0)
+  } else {
+    dat[["y"]] <- dat[["y"]] / sum(dat[["y"]])
+  }
 
 	nms <- colnames(dat)
 	mapping <- ggplot2::aes_string(x = factor(1), y = nms[1], group = nms[2], fill = nms[2], color = nms[2])


### PR DESCRIPTION
fixes: https://github.com/jasp-stats/jasp-test-release/issues/1739
fixes: https://github.com/jasp-stats/jasp-test-release/issues/1706

if `dat$y == c(1, Inf)`

`dat$y <- dat$y / sum(dat$y)`

leads to `Inf / (Inf + 1)` which creates NaNs that crash the plotting function, while the correct outcome should be 1 (all posterior probability is on the second element.