### PR TITLE
update docs with roxygen2 + run examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Graph making functions and wrappers for JASP.
 License: GPL
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Suggests: testthat
 Imports: 
     ggplot2 (>= 3.0.0),

--- a/R/geom_abline2.R
+++ b/R/geom_abline2.R
@@ -6,6 +6,8 @@
 #'
 #' @inheritParams ggplot2::geom_abline
 #' @param method Either "breaks" (default) to respect the extrema of the axes or "ggplot2" to obtain the ggplot2 behavior.
+#' @param slope controls the slope of the lines. If set, \code{data}, \code{mapping} and \code{show.legend} are overridden.
+#' @param intercept controls the intercept of the lines. If set, \code{data}, \code{mapping} and \code{show.legend} are overridden.
 #'
 #' @example inst/examples/ex-geom_abline2.R
 #' @export

--- a/inst/examples/ex-JASPDescriptivesPlot.R
+++ b/inst/examples/ex-JASPDescriptivesPlot.R
@@ -1,4 +1,3 @@
-\dontrun{
 x <- "A"
 y <- -0.188
 ciLower <- y - .1
@@ -39,5 +38,3 @@ yName <- "Performance"
 groupName <- "Legend title"
 descriptivesPlot(x, y, ciLower, ciUpper, xName, yName, group = group, groupName = groupName,
                  breaksAtExtremaOnly = FALSE, connectedPoints = FALSE)
-
-}

--- a/man/descriptivesPlot.Rd
+++ b/man/descriptivesPlot.Rd
@@ -69,7 +69,6 @@ a ggplot2 object.
 Descriptive plot of categorical variable (x-axis) vs. a continuous variable (y-axis)
 }
 \examples{
-\dontrun{
 x <- "A"
 y <- -0.188
 ciLower <- y - .1
@@ -110,6 +109,4 @@ yName <- "Performance"
 groupName <- "Legend title"
 descriptivesPlot(x, y, ciLower, ciUpper, xName, yName, group = group, groupName = groupName,
                  breaksAtExtremaOnly = FALSE, connectedPoints = FALSE)
-
-}
 }

--- a/man/geom_abline2.Rd
+++ b/man/geom_abline2.Rd
@@ -42,13 +42,9 @@ often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
-\item{slope}{Parameters that control the
-position of the line. If these are set, \code{data}, \code{mapping} and
-\code{show.legend} are overridden.}
+\item{slope}{controls the slope of the lines. If set, \code{data}, \code{mapping} and \code{show.legend} are overridden.}
 
-\item{intercept}{Parameters that control the
-position of the line. If these are set, \code{data}, \code{mapping} and
-\code{show.legend} are overridden.}
+\item{intercept}{controls the intercept of the lines. If set, \code{data}, \code{mapping} and \code{show.legend} are overridden.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}

--- a/man/geom_aligned_text.Rd
+++ b/man/geom_aligned_text.Rd
@@ -57,11 +57,7 @@ to the paired geom/stat.}
 \item{parse}{If \code{TRUE}, the labels will be parsed into expressions and
 displayed as described in \code{?plotmath}.}
 
-\item{nudge_x}{Horizontal and vertical adjustment to nudge labels by.
-Useful for offsetting text from points, particularly on discrete scales.
-Cannot be jointly specified with \code{position}.}
-
-\item{nudge_y}{Horizontal and vertical adjustment to nudge labels by.
+\item{nudge_x, nudge_y}{Horizontal and vertical adjustment to nudge labels by.
 Useful for offsetting text from points, particularly on discrete scales.
 Cannot be jointly specified with \code{position}.}
 


### PR DESCRIPTION
Should make the plots appear in the examples of `descriptivesPlot`, because now they don't

![image](https://user-images.githubusercontent.com/21319932/177752523-9e4c2ee0-76aa-4d18-8c59-672749eefdb8.png)
