### PR TITLE
explicitly import GeomSegment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspGraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.5.2.16
+Version: 0.5.2.17
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: Graph making functions and wrappers for JASP.

--- a/R/geom_abline2.R
+++ b/R/geom_abline2.R
@@ -124,7 +124,7 @@ GeomAbline2 <- ggplot2::ggproto(
 
     }
 
-    GeomSegment$draw_panel(unique(data), panel_params, coord)
+    ggplot2::GeomSegment$draw_panel(unique(data), panel_params, coord)
 
   }
 )


### PR DESCRIPTION
A bit embarrassing but without `ggplot2::` the code gave in the following error...
```r
Error in f(...) : object 'GeomSegment' not found
```
this didn't show up in the examples because there I did `library(ggplot2)`.