### PR TITLE
linewidth can now be set in geom_line

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,9 +2,10 @@
 ^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.git$
 
-^.editorconfig
-^.github
+^\.editorconfig$
+^\.github$
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: jaspGraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.5.2.17
+Version: 0.6.0
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: Graph making functions and wrappers for JASP.
 License: GPL
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.3
 Suggests: testthat
 Imports: 
     ggplot2 (>= 3.0.0),

--- a/R/JASPgraphsPlot.R
+++ b/R/JASPgraphsPlot.R
@@ -108,7 +108,7 @@ getDecodeplotFun <- function() {
   jaspBaseInstalled <- length(find.package("jaspBase", .libPaths(), quiet = TRUE, verbose = FALSE)) != 0L
   if (!jaspBaseInstalled)
     return(NULL)
-  if (packageVersion("jaspBase") < "0.16.4")
+  if (utils::packageVersion("jaspBase") < "0.16.4")
     return(get0("decodeplot"))
   else # no longer in the global environment
     return(get0("decodeplot", envir = asNamespace("jaspBase")))

--- a/R/customGeoms.R
+++ b/R/customGeoms.R
@@ -51,7 +51,7 @@ geom_point <- function(mapping = NULL, data = NULL, stat = "identity", position 
 jaspGeomLine <- ggplot2::ggproto(
   `_class`    = "jaspGeomLine",
   `_inherit`  = ggplot2::GeomLine,
-  default_aes = aes(size = 1.00, colour = "black", linetype = 1, alpha = NA)
+  default_aes = aes(linewidth = 1.00, colour = "black", linetype = 1, alpha = NA)
 )
 
 #' @rdname geom_point
@@ -59,7 +59,34 @@ jaspGeomLine <- ggplot2::ggproto(
 geom_line <- function(mapping = NULL, data = NULL, stat = "identity", position = "identity",
     ..., na.rm = FALSE, show.legend = NA, inherit.aes = TRUE) {
 
-  layer(data = data, mapping = mapping, stat = stat, geom = jaspGeomLine,
-        position = position, show.legend = show.legend, inherit.aes = inherit.aes,
-        params = list(na.rm = na.rm, ...))
+  # ggplot2 3.4.0 renamed `size` to `linewidth`. Check if `size` was specified.
+  # If so, rename it to `linewidth` and show a deprecation warning.
+
+  if ("size" %in% ...names()) {
+    lifecycle::deprecate_warn(
+      "0.6.0",
+      "jaspGraphs::geom_line(size)",
+      "jaspGraphs::geom_line(linewidth)",
+      details = "In ggplot2 version 3.4.0 the argument `size` was renamed to `linewidth`, likewise in jaspGraphs. For now, jaspGraphs automatically assigned `linewidth = size`. Please fix this in your code, as this will become an error in a future version of jaspGraphs."
+    )
+
+    # specifying both `size` and `linewidth` is an error
+    if ("linewidth" %in% ...names())
+      stop("`jaspGraphs::geom_line`: Cannot specify both size and linewidth!", domain = NA)
+
+    params <- list(na.rm = na.rm, ...)
+    params[["linewidth"]] <- params[["size"]]
+    params <- params[setdiff(names(params), "size")]
+
+    layer(data = data, mapping = mapping, stat = stat, geom = jaspGeomLine,
+          position = position, show.legend = show.legend, inherit.aes = inherit.aes,
+          params = params)
+
+  } else {
+
+    layer(data = data, mapping = mapping, stat = stat, geom = jaspGeomLine,
+          position = position, show.legend = show.legend, inherit.aes = inherit.aes,
+          params = list(na.rm = na.rm, ...))
+
+  }
 }

--- a/R/graphOptions.R
+++ b/R/graphOptions.R
@@ -16,7 +16,7 @@
   axisTickLength = grid::unit(x = .3, units = "cm"),
   axisTickWidth = .3,
   digits = list(axes = 3L, BF = 3L),
-  ggVersion = packageVersion("ggplot2"),
+  ggVersion = utils::packageVersion("ggplot2"),
   palette = "colorblind",
   debug = TRUE
 ))

--- a/man/geom_abline2.Rd
+++ b/man/geom_abline2.Rd
@@ -18,7 +18,7 @@ geom_abline2(
 )
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or \code{\link[ggplot2:aes_]{aes_()}}.}
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}}.}
 
 \item{data}{The data to be displayed in this layer. There are three
 options:

--- a/man/geom_aligned_text.Rd
+++ b/man/geom_aligned_text.Rd
@@ -22,10 +22,10 @@ geom_aligned_text(
 )
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
-\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
-default), it is combined with the default mapping at the top level of the
-plot. You must supply \code{mapping} if there is no plot mapping.}
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}}. If specified and
+\code{inherit.aes = TRUE} (the default), it is combined with the default mapping
+at the top level of the plot. You must supply \code{mapping} if there is no plot
+mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
 options:
@@ -43,10 +43,12 @@ will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
-layer, as a string.}
+layer, either as a \code{ggproto} \code{Geom} subclass or as a string naming the
+stat stripped of the \code{stat_} prefix (e.g. \code{"count"} rather than
+\code{"stat_count"})}
 
 \item{position}{Position adjustment, either as a string, or the result of
-a call to a position adjustment function. Cannot be jointy specified with
+a call to a position adjustment function. Cannot be jointly specified with
 \code{nudge_x} or \code{nudge_y}.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are

--- a/man/geom_rangeframe.Rd
+++ b/man/geom_rangeframe.Rd
@@ -20,10 +20,10 @@ geom_rangeframe(
 )
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
-\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
-default), it is combined with the default mapping at the top level of the
-plot. You must supply \code{mapping} if there is no plot mapping.}
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}}. If specified and
+\code{inherit.aes = TRUE} (the default), it is combined with the default mapping
+at the top level of the plot. You must supply \code{mapping} if there is no plot
+mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
 options:
@@ -41,10 +41,14 @@ will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{stat}{The statistical transformation to use on the data for this
-layer, as a string.}
+layer, either as a \code{ggproto} \code{Geom} subclass or as a string naming the
+stat stripped of the \code{stat_} prefix (e.g. \code{"count"} rather than
+\code{"stat_count"})}
 
-\item{position}{Position adjustment, either as a string, or the result of
-a call to a position adjustment function.}
+\item{position}{Position adjustment, either as a string naming the adjustment
+(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
+position adjustment function. Use the latter if you need to change the
+settings of the adjustment.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jaspGraphs/issues/85#issuecomment-1597034147

and a few unrelated changes to please the R CMD check.

while `jaspGraphs::geom_point` is pretty different from the ggplot2 default, `geom_line` is not and I don't use it myself anymore. 