### PR TITLE
consistently use 'linewidth' everywhere in jaspGraphs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspGraphs
 Type: Package
 Title: Custom Graphs for JASP
-Version: 0.6.0
+Version: 0.6.1
 Author: Don van den Bergh
 Maintainer: JASP-team <info@jasp-stats.nl>
 Description: Graph making functions and wrappers for JASP.

--- a/R/JASPDescriptivesPlot.R
+++ b/R/JASPDescriptivesPlot.R
@@ -83,7 +83,7 @@ descriptivesPlot <- function(x, y, ciLower = NULL, ciUpper = NULL,
   # length(x) > 1L avoids a warning whenever there is only one value and no lines can be drawn (e.g., the one-sample t-ttest)
   geomLine <- NULL
   if (length(x) > 1L && connectedPoints)
-    geomLine <- ggplot2::geom_line(position = position, size = lineSize)
+    geomLine <- ggplot2::geom_line(position = position, linewidth = lineSize)
 
   p <- ggplot(df, mapping = mapping) +
     ggplot2::geom_errorbar(color = "black", width = errorbarWidth, position = position) +

--- a/R/JASPScatterPlot.R
+++ b/R/JASPScatterPlot.R
@@ -127,7 +127,7 @@ JASPScatterSubPlot <- function(x, group = NULL, type = c("density", "histogram",
 
   if (type == "density") {
     foo <- function(x, ...) as.data.frame(stats::density(x, from = range[1L], to = range[2L])[c("x", "y")])
-    geom <- geom_line(size = 0.5, show.legend = FALSE)
+    geom <- geom_line(linewidth = 0.5, show.legend = FALSE)
     geom2 <- if (colorAreaUnderDensity) {
       geom_ribbon(aes(ymin = 0, ymax = .data$y), alpha = alpha)
     } else {

--- a/R/jaspHistogram.R
+++ b/R/jaspHistogram.R
@@ -156,9 +156,9 @@ jaspHistogram <- function(
       )
 
       densityLineGeom <- ggplot2::geom_line(
-        data    = densDf,
-        mapping = aes(x = .data$x, y = .data$y, group = .data$g, color = .data$g),
-        lwd     = densityLineWidth,
+        data      = densDf,
+        mapping   = aes(x = .data$x, y = .data$y, group = .data$g, color = .data$g),
+        linewidth = densityLineWidth,
       )
 
       scaleColor <- scale_JASPcolor_discrete(name = groupingVariableName)
@@ -179,10 +179,10 @@ jaspHistogram <- function(
       densDf <- data.frame(x = dens[["x"]], y = dens[["y"]])
 
       densityLineGeom <- ggplot2::geom_line(
-        data    = densDf,
-        mapping = aes(x = .data$x, y = .data$y),
-        lwd     = densityLineWidth,
-        col     = "black"
+        data      = densDf,
+        mapping   = aes(x = .data$x, y = .data$y),
+        linewidth = densityLineWidth,
+        col       = "black"
       )
 
       if (densityShade)


### PR DESCRIPTION
otherwise, we see the lifecycle deprecation warning because jaspGraphs does it wrong... :) 