### PR TITLE
JASP´s own color palette

### DIFF
--- a/R/colorPalettes.R
+++ b/R/colorPalettes.R
@@ -6,13 +6,14 @@ jaspGraphs_data <- list2env(list(
   colorblind     = list(colors = RColorBrewer::brewer.pal(8L, "Dark2")),
   colorblind2    = list(colors = RColorBrewer::brewer.pal(8L, "Set2")),
   colorblind3    = list(colors = c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")), # from ggthemes
+  jaspo          = list(colors = c("#00A9E6", "#00BA63", "#BA0057", "#FB8B00", "#956BF8", "#38BBBB", "#633F33", "#EA008B")),  # JASP´s own palette, created by Vincent Ott
   viridis        = list(colors = viridisLite::viridis(256L)), # viridis::scale_color_viridis
   blue           = list(colors = c("#d1e1ec", "#b3cde0", "#6497b1", "#005b96", "#03396c", "#011f4b")), # bayesplot::color_scheme_get("blue")
   gray           = list(colors = c("#DFDFDF", "#bfbfbf", "#999999", "#737373", "#505050", "#383838")), # bayesplot::color_scheme_get("gray")
   ggplot2        = list(colors = c("#F8766D", "#CD9600", "#7CAE00", "#00BE67", "#00BFC4", "#00A9FF", "#C77CFF", "#FF61CC"),
                      fun    = scales::hue_pal()),
   sportsTeamsNBA = list(colors = c("#e13a3e", "#008348", "#061922", "#1d1160", "#860038", "#4d90cd", "#ffc633", "#0f586c", "#00471b", "#005083")), #  unique(teamcolors::league_pal("nba"))[-c(5,7,9,10,13)][1:10]
-  grandBudapest  = list(colors = c("#E6A0C4", "#C6CDF7", "#D8A499", "#7294D4", "#F1BB7B", "#FD6467", "#5B1A18", "#D67236"))# c( wesanderson:::wes_palettes[["GrandBudapest2"]],  wesanderson:::wes_palettes[["GrandBudapest1"]])
+  grandBudapest  = list(colors = c("#E6A0C4", "#C6CDF7", "#D8A499", "#7294D4", "#F1BB7B", "#FD6467", "#5B1A18", "#D67236"))  # c( wesanderson:::wes_palettes[["GrandBudapest2"]],  wesanderson:::wes_palettes[["GrandBudapest1"]])
 ))
 
 #'@title JASP color palettes

--- a/R/colorPalettes.R
+++ b/R/colorPalettes.R
@@ -6,7 +6,7 @@ jaspGraphs_data <- list2env(list(
   colorblind     = list(colors = RColorBrewer::brewer.pal(8L, "Dark2")),
   colorblind2    = list(colors = RColorBrewer::brewer.pal(8L, "Set2")),
   colorblind3    = list(colors = c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")), # from ggthemes
-  jaspo          = list(colors = c("#00A9E6", "#00BA63", "#BA0057", "#FB8B00", "#956BF8", "#38BBBB", "#633F33", "#EA008B")),  # JASP´s own palette, created by Vincent Ott
+  jaspPalette    = list(colors = c("#00A9E6", "#00BA63", "#BA0057", "#FB8B00", "#956BF8", "#38BBBB", "#633F33", "#EA008B")),  # JASP´s own palette, created by Vincent Ott
   viridis        = list(colors = viridisLite::viridis(256L)), # viridis::scale_color_viridis
   blue           = list(colors = c("#d1e1ec", "#b3cde0", "#6497b1", "#005b96", "#03396c", "#011f4b")), # bayesplot::color_scheme_get("blue")
   gray           = list(colors = c("#DFDFDF", "#bfbfbf", "#999999", "#737373", "#505050", "#383838")), # bayesplot::color_scheme_get("gray")


### PR DESCRIPTION
I thought that JASP could use its own color palette.
This is why I propose the JASPO palette.

It currently has 8 colors:
<img width="428" alt="Screenshot 2024-07-13 at 13 54 54" src="https://github.com/user-attachments/assets/952c497a-79df-4006-93f9-ddb0747c246f">

The colors are:
JASP Blue - from JASP´s style guide
JASP Green - style guide
Quartet Red - from the upcoming JASP raincloud plot pre-print
JASP Orange - style guide
Winging-It Violet - I just liked the color
Bayesian Mint - inspired by the cover color of "Bayesian Thinking for Toddlers"
Pantone Cappucino - inspired by https://www.pantone.com/eu/en/color-finder/19-1220-TPX who do not specify a hexcode
Panther´s Pink - inspired by a colorful feline