### PR TITLE
Colorblind Friendlier Palettes + Viridis' Inferno

### DIFF
--- a/R/colorPalettes.R
+++ b/R/colorPalettes.R
@@ -6,8 +6,10 @@ jaspGraphs_data <- list2env(list(
   colorblind     = list(colors = RColorBrewer::brewer.pal(8L, "Dark2")),
   colorblind2    = list(colors = RColorBrewer::brewer.pal(8L, "Set2")),
   colorblind3    = list(colors = c("#000000", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", "#CC79A7")), # from ggthemes
+  colorblind4    = list(colors = c("#61D04F", "#DF536B", "#9E9E9E", "#2297E6", "#CD0BBC", "#000000")),  # From palette.colors(palette = "R4")
   jaspPalette    = list(colors = c("#00A9E6", "#00BA63", "#BA0057", "#FB8B00", "#956BF8", "#38BBBB", "#633F33", "#EA008B")),  # JASP´s own palette, created by Vincent Ott
   viridis        = list(colors = viridisLite::viridis(256L)), # viridis::scale_color_viridis
+  inferno        = list(colors = viridisLite::inferno(256L)),  # Also part of the viridis family
   blue           = list(colors = c("#d1e1ec", "#b3cde0", "#6497b1", "#005b96", "#03396c", "#011f4b")), # bayesplot::color_scheme_get("blue")
   gray           = list(colors = c("#DFDFDF", "#bfbfbf", "#999999", "#737373", "#505050", "#383838")), # bayesplot::color_scheme_get("gray")
   ggplot2        = list(colors = c("#F8766D", "#CD9600", "#7CAE00", "#00BE67", "#00BFC4", "#00A9FF", "#C77CFF", "#FF61CC"),


### PR DESCRIPTION
(see also: https://github.com/jasp-stats/jasp-desktop/pull/5986)

The current colorblind and colorblind2 are not that colorblind friendly, as shown by the package
colorblindcheck::palette_plot()

colorblind:
<img width="524" height="340" alt="Screenshot 2025-07-31 at 19 19 41" src="https://github.com/user-attachments/assets/93c8130f-f848-451b-8507-a893204f950a" />

colorblind2:
<img width="523" height="340" alt="Screenshot 2025-07-31 at 19 25 45" src="https://github.com/user-attachments/assets/c0ded9fe-4506-4ab0-9761-2c62fe010200" />


On the other hand, colorblind3 is better:
<img width="525" height="325" alt="Screenshot 2025-07-31 at 19 21 31" src="https://github.com/user-attachments/assets/ef14c393-fdce-424a-8fbd-8b03670c16bb" />


To add an alternative to colorblind3, I propose colorblind4:
<img width="518" height="331" alt="Screenshot 2025-07-31 at 19 20 47" src="https://github.com/user-attachments/assets/4da79deb-cbd7-414d-92c7-50cd3c0f9b05" />

Note that it is complementary to colorblind3 in the following way.
If only 2 colors are extracted, then colorblind3 will give black and pink, while colorblind4 will give green and black.
Depending on the use case and meaning of the data, this offers flexibilty that users might appreciate.

<br>

Finally, I also added inferno from the viridis family:
<img width="526" height="328" alt="Screenshot 2025-07-31 at 19 24 08" src="https://github.com/user-attachments/assets/5483a003-6528-4f51-99bc-bf1c86d7147f" />
For an additional palette that works for continuous data (like viridis).
