### PR TITLE
add padding for y-axis

### DIFF
--- a/R/convertGgplotToPlotly.R
+++ b/R/convertGgplotToPlotly.R
@@ -47,6 +47,16 @@ convertGgplotToPlotly <- function(ggplotObj, returnJSON = TRUE) {
     plotlyplotje <- ggplotly(pNoRangeframe)
     hasRangeFrame <- FALSE
 
+    # ensure plotly auto-sizes margins so axis titles don't overlap tick labels
+    allXaxes <- grep("^xaxis", names(plotlyplotje$x$layout), value = TRUE)
+    allYaxes <- grep("^yaxis", names(plotlyplotje$x$layout), value = TRUE)
+    for (ax in allXaxes)
+      plotlyplotje$x$layout[[ax]]$automargin <- TRUE
+    for (ax in allYaxes) {
+      plotlyplotje$x$layout[[ax]]$automargin <- TRUE
+      plotlyplotje$x$layout[[ax]]$title$standoff <- 15L
+    }
+
     if (!is.null(temp$shapes)) {
 
       plotlyplotje <- plotly::layout(plotlyplotje,

--- a/R/convertGgplotToPlotly.R
+++ b/R/convertGgplotToPlotly.R
@@ -73,6 +73,16 @@ convertSingleGgplotToPlotly <- function(ggplotObj) {
   plotlyplotje <- fixPlotlyLegendTitle(pNoRangeframe, plotlyplotje)
   hasRangeFrame <- FALSE
 
+  # ensure plotly auto-sizes margins so axis titles don't overlap tick labels
+  allXaxes <- grep("^xaxis", names(plotlyplotje$x$layout), value = TRUE)
+  allYaxes <- grep("^yaxis", names(plotlyplotje$x$layout), value = TRUE)
+  for (ax in allXaxes)
+    plotlyplotje$x$layout[[ax]]$automargin <- TRUE
+  for (ax in allYaxes) {
+    plotlyplotje$x$layout[[ax]]$automargin <- TRUE
+    plotlyplotje$x$layout[[ax]]$title$standoff <- 15L
+  }
+
   if (!is.null(temp$shapes)) {
 
     plotlyplotje <- plotly::layout(plotlyplotje,


### PR DESCRIPTION
Fix https://github.com/jasp-stats/INTERNAL-jasp/issues/3179

The padding is now hardcoded as 15px but could maybe be increased?

Before
<img width="1436" height="1198" alt="Rplot1" src="https://github.com/user-attachments/assets/c6e592db-6b0a-4249-88dc-9475de97f94e" />

After
<img width="1436" height="1198" alt="Rplot2" src="https://github.com/user-attachments/assets/7090d494-53a0-4478-a5a9-3af6554dec84" />


Before
<img width="1436" height="1198" alt="Rplot-qq1" src="https://github.com/user-attachments/assets/12f0d5c4-792f-4f47-984e-1e7f50ef86df" />

After
<img width="1436" height="1198" alt="Rplot-qq2" src="https://github.com/user-attachments/assets/cca45599-9dfe-4373-b7f4-bf47cd3e6d8c" />
